### PR TITLE
Better filename recognition

### DIFF
--- a/lib/GitDiff.class.php
+++ b/lib/GitDiff.class.php
@@ -148,7 +148,8 @@ class GitDiffFile {
   }
  
   private function get_file_name() {
-    preg_match("#.*b/(.*)$#i", $this->header, $matches);
+    // See: https://git-scm.com/docs/git-diff#_generating_patches_with_p
+    preg_match("#diff --git a\/(.*) b\/\\1$#i", $this->header, $matches);
     return $matches[1];
   }
   


### PR DESCRIPTION
This fixes a bug where paths like `b/vendor/lib/file.ext` would incorrectly return `file.ext` instead of vendor/lib/file.ext.

An example diff header line that broke is as follows:
`diff --git a/vendors/php-activerecord-master/lib/Cache.php b/vendors/php-activerecord-master/lib/Cache.php`